### PR TITLE
readme: add help and contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,11 @@ user: |
   
   {{ code }}
 ```
+
+## Contributing
+
+See the [contributing guide](CONTRIBUTING.md) for more information.
+
 ## 📄 License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Fraim empowers security teams to easily create, customize, and deploy AI workflo
 ![UI Preview](assets/ui-preview.gif)
 *Output of running the `code` workflow*
 
+## Help
+
+See the [docs](https://docs.fraim.dev) for more information.
 
 ## 🚀 Quick Start
 


### PR DESCRIPTION
## What?

Add two small sections to the readme:

1. "Help" links to the docs page
2. "Contributing" links to `CONTIBUTING.MD`