### PR TITLE
Fix path when --output flag is passed

### DIFF
--- a/fraim/cli.py
+++ b/fraim/cli.py
@@ -20,7 +20,7 @@ def parse_args_to_scan_args(args: argparse.Namespace) -> ScanArgs:
 def parse_args_to_config(args: argparse.Namespace) -> Config:
     """Convert FetchRepoArgs to Config object."""
     return Config(
-        scan_dir=os.path.dirname(args.output) if args.output else str(Path(__file__).parent.parent / "scan_outputs"),
+        scan_dir=args.output if args.output else str(Path(__file__).parent.parent / "scan_outputs"),
         debug_mode=args.debug,
         model=args.model,
         processes=args.processes,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The --output flag was previously being passed to config by using `os.path.dirname(output_flag_contents)`, however if the user just passed in a relative path with no `/` it would return dirname as `''`. This line was a mistake in general, since presumably the person running this command always wants the output to be relative to the directory they're running in, so we can just use the contents of the output flag directly if they exist.

## Related Tickets & Documents
- Closes https://github.com/fraim-dev/fraim/issues/14
