### PR TITLE
re-enable the CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ dev ]
+    branches: [ main ]
   pull_request:
-    branches: [ dev ]
 
 jobs:
   test:

--- a/fraim/cli.py
+++ b/fraim/cli.py
@@ -7,25 +7,19 @@ import multiprocessing as mp
 import os
 from pathlib import Path
 
-from fraim.observability.logging import make_logger
-from fraim.scan import scan, ScanArgs
 from fraim.config.config import Config
 from fraim.observability import ObservabilityManager, ObservabilityRegistry
+from fraim.observability.logging import make_logger
 from fraim.scan import ScanArgs, scan
-from fraim.workflows import WorkflowRegistry
 from fraim.validate_cli import validate_cli_args
+from fraim.workflows import WorkflowRegistry
 
 
 def parse_args_to_scan_args(args: argparse.Namespace) -> ScanArgs:
     """Convert argparse Namespace to typed FetchRepoArgs dataclass."""
-    return ScanArgs(
-        repo=args.repo,
-        path=args.path,
-        workflows=args.workflows,
-        globs=args.globs,
-        limit=args.limit
-    )
-    
+    return ScanArgs(repo=args.repo, path=args.path, workflows=args.workflows, globs=args.globs, limit=args.limit)
+
+
 def parse_args_to_config(args: argparse.Namespace) -> Config:
     """Convert FetchRepoArgs to Config object."""
     output_dir = args.output if args.output else str(Path(__file__).parent.parent / "fraim_output")
@@ -33,8 +27,8 @@ def parse_args_to_config(args: argparse.Namespace) -> Config:
     # Default logger
     logger = make_logger(
         name="fraim",
-        level = logging.DEBUG if args.debug else logging.INFO,
-        path = os.path.join(output_dir, "fraim_scan.log"),
+        level=logging.DEBUG if args.debug else logging.INFO,
+        path=os.path.join(output_dir, "fraim_scan.log"),
         show_logs=args.show_logs,
     )
     return Config(
@@ -71,8 +65,7 @@ def build_workflows_arg(parser: argparse.ArgumentParser) -> None:
         help_parts.append(f"{workflow}: {description}")
     workflows_help = f" - {'\n - '.join(help_parts)}"
 
-    parser.add_argument("--workflows", nargs="+",
-                        choices=workflow_choices, help=workflows_help, required=True)
+    parser.add_argument("--workflows", nargs="+", choices=workflow_choices, help=workflows_help, required=True)
 
 
 def build_observability_arg(parser: argparse.ArgumentParser) -> None:
@@ -91,11 +84,11 @@ def build_observability_arg(parser: argparse.ArgumentParser) -> None:
 
     parser.add_argument("--observability", nargs="+", choices=available_backends, default=[], help=observability_help)
 
+
 def cli() -> int:
     """Main entry point for the script."""
     parser = argparse.ArgumentParser(
-        description="Scan a repository for security vulnerabilities.",
-        formatter_class=argparse.RawTextHelpFormatter
+        description="Scan a repository for security vulnerabilities.", formatter_class=argparse.RawTextHelpFormatter
     )
 
     #############################
@@ -142,7 +135,7 @@ def cli() -> int:
     )
     parser.add_argument("--limit", type=int, help="Limit the number of files to scan")
 
-    parser.add_argument('--show-logs', type=bool, default=True, help='Prints logs to standard error output')
+    parser.add_argument("--show-logs", type=bool, default=True, help="Prints logs to standard error output")
 
     parsed_args = parser.parse_args()
 
@@ -155,7 +148,6 @@ def cli() -> int:
     except Exception as e:
         print(f"CLI Validation Error: {e}")
         exit(1)
-        
 
     # Parse config to get logger
     config = parse_args_to_config(parsed_args)

--- a/fraim/config/config.py
+++ b/fraim/config/config.py
@@ -69,7 +69,6 @@ class Config:
         self.logger = logger
         # self.limit = limit
 
-
     def _get_provider_from_model(self, model: str) -> str:
         """Extract the provider from the model name."""
         if "/" in model:

--- a/fraim/observability/logging.py
+++ b/fraim/observability/logging.py
@@ -4,7 +4,7 @@ import sys
 # TODO: Consider JSON formatting, this makes it very easy to integrate dashboards, etc.
 #       We could then have a reader that renders these log events differently.
 
-def make_logger(name = None, level= logging.INFO, path: str = None, show_logs = False) -> logging.Logger:
+def make_logger(name: str | None = None, level: int = logging.INFO, path: str | None = None, show_logs: bool = False) -> logging.Logger:
     logger = logging.getLogger(name) # Get or create logger instance by name
 
     logger.setLevel(level) # Set the log level, always overwriting
@@ -24,14 +24,14 @@ def make_logger(name = None, level= logging.INFO, path: str = None, show_logs = 
     return logger
 
 
-def file_handler(level, path):
+def file_handler(level: int, path: str) -> logging.FileHandler:
     handler = logging.FileHandler(path)
     handler.setLevel(level)
     handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
     return handler
 
 
-def stderr_handler(level):
+def stderr_handler(level: int) -> logging.StreamHandler:
     handler = logging.StreamHandler(stream=sys.stderr)
     handler.setLevel(level)
     handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))

--- a/fraim/observability/logging.py
+++ b/fraim/observability/logging.py
@@ -4,10 +4,13 @@ import sys
 # TODO: Consider JSON formatting, this makes it very easy to integrate dashboards, etc.
 #       We could then have a reader that renders these log events differently.
 
-def make_logger(name: str | None = None, level: int = logging.INFO, path: str | None = None, show_logs: bool = False) -> logging.Logger:
-    logger = logging.getLogger(name) # Get or create logger instance by name
 
-    logger.setLevel(level) # Set the log level, always overwriting
+def make_logger(
+    name: str | None = None, level: int = logging.INFO, path: str | None = None, show_logs: bool = False
+) -> logging.Logger:
+    logger = logging.getLogger(name)  # Get or create logger instance by name
+
+    logger.setLevel(level)  # Set the log level, always overwriting
 
     # Ensure the logger is fresh by removing all existing handlers
     if logger.hasHandlers():
@@ -27,12 +30,12 @@ def make_logger(name: str | None = None, level: int = logging.INFO, path: str | 
 def file_handler(level: int, path: str) -> logging.FileHandler:
     handler = logging.FileHandler(path)
     handler.setLevel(level)
-    handler.setFormatter(logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s"))
     return handler
 
 
 def stderr_handler(level: int) -> logging.StreamHandler:
     handler = logging.StreamHandler(stream=sys.stderr)
     handler.setLevel(level)
-    handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
     return handler

--- a/fraim/scan.py
+++ b/fraim/scan.py
@@ -32,6 +32,7 @@ class ScanArgs:
     globs: Optional[List[str]] = None
     limit: Optional[int] = None
 
+
 # Use module-specific globs if available, otherwise fall back to provided globs
 def resolve_file_patterns(args: ScanArgs) -> List[str]:
     if args.globs:
@@ -131,8 +132,7 @@ def scan(args: ScanArgs, config: Config, observability_backends: Optional[List[s
         Reporting.generate_html_report(sarif_report=report, repo_name=repo_name, output_path=html_output_file)
         config.logger.info(f"Wrote HTML report ({total_results} results) to {html_output_file}")
     except Exception as e:
-        config.logger.error(
-            f"Failed to write HTML report to {html_output_file}: {str(e)}")
+        config.logger.error(f"Failed to write HTML report to {html_output_file}: {str(e)}")
 
 
 def generate_file_chunks(

--- a/fraim/validate_cli.py
+++ b/fraim/validate_cli.py
@@ -1,10 +1,11 @@
-import os
 import argparse
+import os
 from typing import Dict, TypedDict
 
 
 class ProviderDetails(TypedDict):
     """Type definition for provider details."""
+
     env_var: str
     example_model: str
     display_name: str
@@ -13,17 +14,19 @@ class ProviderDetails(TypedDict):
 def validate_cli_args(args: argparse.Namespace) -> None:
     """Validate CLI arguments."""
     validate_input(args)
-    
+
     # Validate model and API key compatibility
     validate_model_api_key(args.model)
-    
+
+
 def validate_input(args: argparse.Namespace) -> None:
     """Validate input."""
     if args.repo and args.path:
         raise ValueError("Specify only one input. Cannot specify both --repo and --path")
     if not args.repo and not args.path:
         raise ValueError("Must specify one input. Specify either --repo or --path")
-    
+
+
 def validate_model_api_key(model: str) -> None:
     """Validate that the model and API key match."""
     # Map providers to their expected environment variables
@@ -44,21 +47,21 @@ def validate_model_api_key(model: str) -> None:
             "display_name": "Google",
         },
     }
-    
+
     # Extract provider from model name
     if "/" not in model:
         # If no provider specified, skip validation
         return
-    
+
     provider = model.split("/")[0].lower()
-    
+
     # Check if we know about this provider
     if provider not in provider_details:
         # Unknown provider, skip validation
         return
-    
+
     expected_env_var = provider_details[provider]["env_var"]
-    
+
     # Check if the required API key is set
     if not os.environ.get(expected_env_var):
         # Check if user has other provider API keys set
@@ -67,10 +70,10 @@ def validate_model_api_key(model: str) -> None:
             if other_env_var and other_env_var != expected_env_var and os.environ.get(other_env_var):
                 other_provider_display = details["display_name"]
                 provider_display = provider_details[provider]["display_name"]
-                
+
                 example_model = details["example_model"]
                 other_env_var = details["env_var"]
-                
+
                 raise ValueError(
                     f"The selected model is {model}, but you provided an API key for {other_provider_display} ({other_env_var}). "
                     f"Specify a {other_provider_display} model (Ex: --model={example_model}) or provide an API key for {provider_display} ({expected_env_var})."


### PR DESCRIPTION
## Description

Re-enable the Github Actions CI workflow.  This was accidentally disabled when we renamed the primary branch from `dev` to `main`. The workflow still referenced the old `dev` name.

We've merged some commits since that fail `make typecheck` and `make format-check`, so this PR fixes those as well.