### PR TITLE
Fix diff command line argument

### DIFF
--- a/fraim/core/workflows/chunk_processing.py
+++ b/fraim/core/workflows/chunk_processing.py
@@ -26,7 +26,6 @@ class ChunkWorkflowInput(WorkflowInput):
     """Base input for chunk-based workflows."""
 
     config: Config
-    diff: Annotated[bool, {"help": "Whether to use git diff input"}]
     head: Annotated[str, {"help": "Git head commit for diff input"}]
     base: Annotated[str, {"help": "Git base commit for diff input"}]
     location: Annotated[str, {"help": "Repository URL or path to scan"}]
@@ -37,6 +36,11 @@ class ChunkWorkflowInput(WorkflowInput):
         {"help": "Globs to use for file scanning. If not provided, will use workflow-specific defaults."},
     ] = None
     max_concurrent_chunks: Annotated[int, {"help": "Maximum number of chunks to process concurrently"}] = 5
+
+    diff: Annotated[bool, {"help": (
+        "Whether to use git diff input. If --head and --base are not specified, "
+        "the working tree is scanned."
+    )}] = False
 
 
 class ChunkProcessingMixin:

--- a/fraim/core/workflows/chunk_processing.py
+++ b/fraim/core/workflows/chunk_processing.py
@@ -37,10 +37,14 @@ class ChunkWorkflowInput(WorkflowInput):
     ] = None
     max_concurrent_chunks: Annotated[int, {"help": "Maximum number of chunks to process concurrently"}] = 5
 
-    diff: Annotated[bool, {"help": (
-        "Whether to use git diff input. If --head and --base are not specified, "
-        "the working tree is scanned."
-    )}] = False
+    diff: Annotated[
+        bool,
+        {
+            "help": (
+                "Whether to use git diff input. If --head and --base are not specified, the working tree is scanned."
+            )
+        },
+    ] = False
 
 
 class ChunkProcessingMixin:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update

## Description

Removes the requirement for passing an argument with `--diff`.  Running the code workflow in diff mode now looks like:

> uv run fraim code --diff --location .

This also adds a note to the --diff help message that the working tree is scanned when neither --head or --base are used.


## Related Tickets & Documents

I said I would fix this in the comments of https://github.com/fraim-dev/fraim/pull/78#issuecomment-3189685793 because I assumed I had implemented the boolean feature on my branch. This wasn't true, it seems I was confused and the feature already was implemented, but either way this PR makes `--diff` work as it was intended.
