### PR TITLE
Bug Fixes - Message Content is None, Project('') not found, Project(..) already exists

### DIFF
--- a/fraim/core/steps/llm.py
+++ b/fraim/core/steps/llm.py
@@ -125,7 +125,8 @@ class LLMStep(BaseStep[TDynamicInput, TOutput], Generic[TDynamicInput, TOutput])
         # At this point, choice is guaranteed to be of type Choices
         message_content = choice.message.content
         if message_content is None:
-            raise ValueError("Message content is None")
+            # Setting message_content to empty string will always fail to parse, which will trigger a retry.
+            message_content = ""
 
         context = ParseContext(llm=self.llm, messages=messages)
         return await self.parser.parse(message_content, context=context)

--- a/fraim/core/steps/llm.py
+++ b/fraim/core/steps/llm.py
@@ -126,6 +126,15 @@ class LLMStep(BaseStep[TDynamicInput, TOutput], Generic[TDynamicInput, TOutput])
         message_content = choice.message.content
         if message_content is None:
             # Setting message_content to empty string will always fail to parse, which will trigger a retry.
+            #
+            # The model API _should_ always return a message here, but the Gemini API (as of August 2025) 
+            # sometimes does not.
+            # 
+            # See the similar issues reported other projects:
+            # gemini-cli: https://github.com/google-gemini/gemini-cli/issues/6306
+            # n8n: https://github.com/n8n-io/n8n/issues/18481
+            #
+            # If/when the Gemini API is fixed, consider removing this workaround.
             message_content = ""
 
         context = ParseContext(llm=self.llm, messages=messages)

--- a/fraim/inputs/project.py
+++ b/fraim/inputs/project.py
@@ -40,8 +40,9 @@ class ProjectInput:
             self.input = GitRemote(self.config, url=path_or_url, globs=globs, limit=limit, prefix="fraim_scan_")
             self.project_path = self.input.root_path()
         else:
-            self.project_path = path_or_url
-            self.repo_name = os.path.basename(os.path.abspath(self.project_path))
+            # Fully resolve the path to the project
+            self.project_path = os.path.abspath(path_or_url)
+            self.repo_name = os.path.basename(self.project_path)
             if self.diff:
                 self.input = GitDiff(
                     self.config, self.project_path, head=self.head, base=self.base, globs=globs, limit=limit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fraim"
-version = "0.5.0"
+version = "0.5.1"
 description = "A CLI app that runs AI-powered security workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -251,7 +251,7 @@ wheels = [
 
 [[package]]
 name = "fraim"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
There are three fixes in this PR for various issues

# Message Content is None
Sometimes Gemini returns back nothing, in this case we want to retry. To do this we just pass back an empty string that fails parsing, which will auto retry

# Project('') not found
This happens when the user uses `./` as their path and instantiates the TreeSitterTools. To fix this we just fully resolve the path before calling the workflow.

#  Project(..) already exists
This is a race condition when running multiple threads with TreeSitterTools. To fix this we set a lock when initializing the triager_step (which is responsible for initializing the TreeSitterTools in the code workflow)