### PR TITLE
Fix PR Comment to not add new line on strings like 10.0.0.0

### DIFF
--- a/fraim/core/workflows/format_pr_comment.py
+++ b/fraim/core/workflows/format_pr_comment.py
@@ -27,7 +27,7 @@ The following security risks have been identified and require review:
 **Location**: `{{ risk.locations[0].physicalLocation.artifactLocation.uri }}:{{ risk.locations[0].physicalLocation.region.startLine }}`
 
 **Explanation**:
-{%- for explanation in risk.properties.explanation.split('.') %}
+{%- for explanation in risk.properties.explanation.split('. ') %}
 {%- if explanation.strip() %}
 * {{ explanation.strip() }}.
 {%- endif %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The risk flagger workflow uses formats a PR comment by splitting every period (`.`) out of a string and adding it to a bulleted list. This looks bad when the explanation has something like an IP address because it will split them up and add every section to a new line. To fix this, we only split when we see a space after the period.