### PR TITLE
litellm: set modify_params

### DIFF
--- a/fraim/core/llms/litellm.py
+++ b/fraim/core/llms/litellm.py
@@ -17,8 +17,14 @@ from fraim.core.tools import BaseTool, execute_tool_calls
 from fraim.core.utils.retry.tenacity import with_retry
 
 
-def _configure_litellm_logging() -> None:
-    """Configure LiteLLM logging to be less verbose."""
+# Configure LiteLLM on module import
+def _configure_litellm() -> None:
+    # Allow LiteLLM to modify completion paramters to paper over
+    # differences across the various providers. For example,
+    # OpenAI allows a null "tools" parameter, while Anthropic requires
+    # an empty list instead.
+    litellm.modify_params = True
+
     # Silence LiteLLM loggers
     litellm_loggers = [
         "httpx",
@@ -41,8 +47,7 @@ def _configure_litellm_logging() -> None:
         logger.setLevel(logging.ERROR)
 
 
-# Configure LiteLLM logging on module import
-_configure_litellm_logging()
+_configure_litellm()
 
 
 class Config(Protocol):


### PR DESCRIPTION
 `litellm.modify_params = True` tells LiteLLM that is may automatically paper over API differences across providers. For example, OpenAI and Gemini support a missing/null "tools" argument, but Anthropic requires an empty list. If our code passes None, LiteLLM will replace it with an empty list when calling an Anthropic model.

