### PR TITLE
Do not fail risk_flagger workflow if requesting reviewer fails

### DIFF
--- a/fraim/actions/__init__.py
+++ b/fraim/actions/__init__.py
@@ -2,6 +2,6 @@
 Actions module for performing external actions like notifications.
 """
 
-from fraim.actions.github import add_reviewer
+from fraim.actions.github import add_comment, add_reviewer
 
-__all__ = ["add_reviewer"]
+__all__ = ["add_reviewer", "add_comment"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fraim"
-version = "0.6.0"
+version = "0.6.1"
 description = "A CLI app that runs AI-powered security workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ wheels = [
 
 [[package]]
 name = "fraim"
-version = "0.6.0"
+version = "0.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "gitpython" },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Right now the risk_flagger workflow will fail if it is not able to request a reviewer. Since Github Actions do not have the permissions to request a reviewer let's not fail so that at least the comment gets pushed. The user can create a PAT or Github App if they want the reviewer to be requested on the PR