### PR TITLE
chunk_processing: do not duplicate results

### DIFF
--- a/fraim/core/workflows/chunk_processing.py
+++ b/fraim/core/workflows/chunk_processing.py
@@ -176,9 +176,6 @@ class ChunkProcessor(Generic[T]):
                 _done, active_tasks = await asyncio.wait(active_tasks, return_when=asyncio.FIRST_COMPLETED)
 
         # Wait for any remaining tasks to complete
-        if active_tasks:
-            for future in asyncio.as_completed(active_tasks):
-                chunk_results = await future
-                self._results.extend(chunk_results)
+        await asyncio.gather(*active_tasks)
 
         return self._results


### PR DESCRIPTION
## Description

Fix a bug where the `chunk_processor` would store a duplicate copy of any results produced by the final tasks.  Also simplify how we wait for those final tasks to complete, now that we don't need to do anything with the tasks return value.