### PR TITLE
constrain enums in pydantic models

### DIFF
--- a/fraim/outputs/sarif.py
+++ b/fraim/outputs/sarif.py
@@ -101,7 +101,9 @@ class ResultProperties(BaseSchema):
 
     type: str = Field(description="Type of vulnerability (e.g., 'SQL Injection', 'XSS', 'Command Injection', etc.)")
     confidence: int = Field(
-        description="Confidence that the result is a true positive from 1 (least confident) to 10 (most confident)"
+        ge=1,
+        le=10,
+        description="Confidence that the result is a true positive from 1 (least confident) to 10 (most confident)",
     )
     exploitable: bool = Field(description="True if the vulnerability is exploitable, false otherwise.")
     explanation: Message = Field(description="Explanation of the exploitability of the vulnerability.")

--- a/fraim/workflows/risk_flagger/risk_sarif_overlay.py
+++ b/fraim/workflows/risk_flagger/risk_sarif_overlay.py
@@ -6,6 +6,8 @@ Risk Flagger workflow-specific SARIF model extensions.
 These models extend the base SARIF models with additional fields.
 """
 
+from typing import Literal
+
 from pydantic import Field
 
 from fraim.outputs.sarif import BaseSchema
@@ -16,12 +18,14 @@ class ResultProperties(BaseSchema):
     risk_type: str = Field(
         description="The category of risk identified (e.g., 'Database Changes', 'Public Facing VMs'). Must match one of the risks specified in the workflow configuration."
     )
-    risk_severity: str = Field(
-        description="The assessed impact level of the risk ('critical', 'high', 'medium', 'low'). Based on potential security impact and exposure surface area."
+    risk_severity: Literal["critical", "high", "medium", "low"] = Field(
+        description="The assessed impact level of the risk. Based on potential security impact and exposure surface area."
     )
     explanation: str = Field(
         description="Detailed technical explanation of why this code change introduces risk. Should include: 1) What specific change triggered the risk flag, 2) How it relates to the risk type, 3) What security implications need investigation."
     )
     confidence: int = Field(
-        description="Confidence that the result is a true risk from 1 (least confident) to 10 (most confident). Higher confidence (8-10) requires clear evidence in code changes. Lower confidence (1-4) indicates more context needed. Where more context is needed, use the tools available to you to gather that context."
+        ge=1,
+        le=10,
+        description="Confidence that the result is a true risk from 1 (least confident) to 10 (most confident). Higher confidence (8-10) requires clear evidence in code changes. Lower confidence (1-4) indicates more context needed. Where more context is needed, use the tools available to you to gather that context.",
     )


### PR DESCRIPTION
## Description

Add constraints to the SARIF pydantic output models to force the LLM to produce correct output.

- The `Result` `confidence` should be an integer between 1 and 10. Enforce this with >= 1 and <= 10 constraints. Previously, the LLM would sometimes produce a percentage 10, 20, 30, etc.

- The risk flagger `risk_severity` must be one of 'critical', 'high', 'medium', 'low'.

