### PR TITLE
Better formatting in GitHub PR comment

### DIFF
--- a/fraim/core/workflows/format_pr_comment.py
+++ b/fraim/core/workflows/format_pr_comment.py
@@ -22,7 +22,7 @@ The following security risks have been identified and require review:
 ## {{ risk_type }}
 {%- for risk in type_risks %}
 
-### {{ risk.message }} (Severity: {{ risk.properties.risk_severity }})
+### {{ risk.message.text }} (Severity: {{ risk.properties.risk_severity }})
 
 **Location**: `{{ risk.locations[0].physicalLocation.artifactLocation.uri }}:{{ risk.locations[0].physicalLocation.region.startLine }}`
 

--- a/fraim/core/workflows/format_pr_comment.py
+++ b/fraim/core/workflows/format_pr_comment.py
@@ -33,7 +33,7 @@ The following security risks have been identified and require review:
 {%- endif %}
 {%- endfor %}
 
-**Confidence**: {{ risk.properties.confidence }}%
+**Confidence**: {{ risk.properties.confidence * 10 }}%
 
 ---
 {%- endfor %}


### PR DESCRIPTION
## Description

Two improvements to the Github PR comment format produced by the risk flagger.

- Format the confidence as a percentage. The LLM produce a number 1-10, so multiply that by 10.

- The `Result.message` is itself an object with a `text` property.  Only include this text in the comment. Previously we were outputting `text = "the real message", which looked weird.
