### PR TITLE
Remove confidence from PR Comment

### DIFF
--- a/fraim/core/workflows/format_pr_comment.py
+++ b/fraim/core/workflows/format_pr_comment.py
@@ -33,8 +33,6 @@ The following security risks have been identified and require review:
 {%- endif %}
 {%- endfor %}
 
-**Confidence**: {{ risk.properties.confidence }}%
-
 ---
 {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Confidence is used for filtering results, but we do not need to show it to the end user so just remove it from the PR comment