### PR TITLE
workflow: remove explicit logger arg from workflow mixins

### DIFF
--- a/fraim/core/workflows/chunk_processing.py
+++ b/fraim/core/workflows/chunk_processing.py
@@ -57,7 +57,7 @@ class ChunkProcessor(Generic[T]):
     """
 
     def __init__(self, args: ChunkProcessingOptions) -> None:
-        super().__init__(logger, args)  # type: ignore
+        super().__init__(args)  # type: ignore
 
         # Progress tracking attributes
         self._total_chunks = 0

--- a/fraim/core/workflows/llm_processing.py
+++ b/fraim/core/workflows/llm_processing.py
@@ -20,7 +20,7 @@ class LLMOptions:
 
 class LLMMixin:
     def __init__(self, args: LLMOptions):
-        super().__init__(logger, args)  # type: ignore
+        super().__init__(args)  # type: ignore
 
         self.llm = LiteLLM(
             model=args.model,


### PR DESCRIPTION
## Description

Fix an oversight in #118 - remove the explicit logger from the `super().__init__` calls as well.  Surprised mypy didn't catch this...