### PR TITLE
Pin codecov/codecov-action to SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         make test-cov
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238
       with:
         file: ./coverage.xml
         fail_ci_if_error: false


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
Other Actions in this file are pinned to a SHA, updating here to match.

## Related Tickets & Documents
https://github.com/codecov/codecov-action/releases/tag/v4